### PR TITLE
fetching raghava trello data to gold table

### DIFF
--- a/jobs/raghava_nelbo_trello_to_gold.py
+++ b/jobs/raghava_nelbo_trello_to_gold.py
@@ -1,8 +1,7 @@
 """
-This script will fetch all the cards of a trello board that according to the below criteria:
-- present in doing list
-- does not have any activity from past specified days
-Save the data to Delta Lake Gold table
+This script will fetch all the cards of a Trello board according to the defined criteria:
+This script fetches all the Trello cards that I have worked on over a period of time 
+and place it in a Gold delta table
 This script is scheduled to run twice a week
 """
 
@@ -13,17 +12,14 @@ import argparse
 from loguru import logger
 from pyspark.sql.functions import col
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from helpers import spark_helper as sh, common_functions as cf, trello_functions as tf
+from helpers import spark_helper as sh
 from config import delta_table_conf as dc
 
-def get_activity_cards(start_date,end_date):
+def get_member_cards(start_date,end_date):
     """
     Fetch all the cards data between provided date range and
-    active from past specified days and save it into a Delta Lake Gold table
+    save it into a Delta Lake Gold table
     :param spark: Spark session
-    :param board_id: trello board id
-    :param board_name: trello board name
-    :param no_of_days: number of days the cards are not active
     :return none
     """
     path = dc.raghava_cards_gold_path
@@ -32,21 +28,21 @@ def get_activity_cards(start_date,end_date):
 
         # Fetch the cards data from the refined cards silver delta table
         refined_cards_data = spark.read.format(
-            "delta").load(dc.cards_silver_table_path)
+            "delta").load(dc.cards_unique_silver_table_path)
         logger.info(f'Fetched the refined cards data from silver table')
 
         # trim date using datetime
         start_date = datetime.strptime(start_date,'%Y-%m-%d')
         end_date = datetime.strptime(end_date,'%Y-%m-%d')
         # filter the data based on name, start date and end date
-        filtered_data = refined_cards_data.filter(col("card_members").contains('raghavanelabhotla') & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
+        filtered_data = refined_cards_data.filter(col("card_members").contains("%raghavanelabhotla%") & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
 
         #Select the required columns
-        active_cards_data = filtered_data.select(
+        member_cards_data = filtered_data.select(
             "id", "name", "card_members", "LastUpdated", "board_name")
 
         #Write the data to Delta Lake Gold table
-        active_cards_data.write.format('delta').mode(
+        member_cards_data.write.format('delta').mode(
             "overwrite").option("mergeSchema", 'true').save(path)
 
         logger.success(
@@ -67,5 +63,4 @@ if __name__ == "__main__":
     PARSER.add_argument('--end_date', metavar='end date', required=True,
                          help='end date')
     ARGS = PARSER.parse_args()
-    
-    get_activity_cards(ARGS.start_date, ARGS.end_date)
+    get_member_cards(ARGS.start_date, ARGS.end_date)

--- a/jobs/raghava_nelbo_trello_to_gold.py
+++ b/jobs/raghava_nelbo_trello_to_gold.py
@@ -35,7 +35,7 @@ def get_member_cards(start_date,end_date):
         start_date = datetime.strptime(start_date,'%Y-%m-%d')
         end_date = datetime.strptime(end_date,'%Y-%m-%d')
         # filter the data based on name, start date and end date
-        filtered_data = refined_cards_data.filter(col("card_members").contains("%raghavanelabhotla%") & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
+        filtered_data = refined_cards_data.filter(col("card_members").contains("raghava.nelabhotla") & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
 
         #Select the required columns
         member_cards_data = filtered_data.select(

--- a/jobs/raghava_nelbo_trello_to_gold.py
+++ b/jobs/raghava_nelbo_trello_to_gold.py
@@ -1,0 +1,71 @@
+"""
+This script will fetch all the cards of a trello board that according to the below criteria:
+- present in doing list
+- does not have any activity from past specified days
+Save the data to Delta Lake Gold table
+This script is scheduled to run twice a week
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+import argparse
+from loguru import logger
+from pyspark.sql.functions import col
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from helpers import spark_helper as sh, common_functions as cf, trello_functions as tf
+from config import delta_table_conf as dc
+
+def get_activity_cards(start_date,end_date):
+    """
+    Fetch all the cards data between provided date range and
+    active from past specified days and save it into a Delta Lake Gold table
+    :param spark: Spark session
+    :param board_id: trello board id
+    :param board_name: trello board name
+    :param no_of_days: number of days the cards are not active
+    :return none
+    """
+    path = dc.raghava_cards_gold_path
+    try:
+        spark, context = sh.start_spark()
+
+        # Fetch the cards data from the refined cards silver delta table
+        refined_cards_data = spark.read.format(
+            "delta").load(dc.cards_silver_table_path)
+        logger.info(f'Fetched the refined cards data from silver table')
+
+        # trim date using datetime
+        start_date = datetime.strptime(start_date,'%Y-%m-%d')
+        end_date = datetime.strptime(end_date,'%Y-%m-%d')
+        # filter the data based on name, start date and end date
+        filtered_data = refined_cards_data.filter(col("card_members").contains('raghavanelabhotla') & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
+
+        #Select the required columns
+        active_cards_data = filtered_data.select(
+            "id", "name", "card_members", "LastUpdated", "board_name")
+
+        #Write the data to Delta Lake Gold table
+        active_cards_data.write.format('delta').mode(
+            "overwrite").option("mergeSchema", 'true').save(path)
+
+        logger.success(
+            f'\n Saved raghava cards data to {path}')
+        logger.info(
+            f'Saved raghava cards data for boardto {path} table')
+
+    except Exception as error:
+        logger.exception(
+            f'Exception while fetching cards for')
+        raise error
+
+# --------START OF SCRIPT
+if __name__ == "__main__":
+    PARSER = argparse.ArgumentParser(description='Create gold delta table')
+    PARSER.add_argument('--start_date', metavar='starting date', required=True,
+                        help='start date')
+    PARSER.add_argument('--end_date', metavar='end date', required=True,
+                         help='end date')
+    ARGS = PARSER.parse_args()
+    
+    get_activity_cards(ARGS.start_date, ARGS.end_date)


### PR DESCRIPTION
python raghava_nelbo_trello_to_gold.py --start_date='2022-08-01' --end_date='2023-02-20'

loading settings :: url = jar:file:/home/lakeuser/lakehouse_project/venv/lib/python3.8/site-packages/pyspark/jars/ivy-2.5.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
Ivy Default Cache set to: /home/lakeuser/.ivy2/cache
The jars for the packages stored in: /home/lakeuser/.ivy2/jars
io.delta#delta-core_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-d50c196c-7782-4293-b6ec-3c81ffd334e4;1.0
	confs: [default]
	found io.delta#delta-core_2.12;2.1.1 in central
	found io.delta#delta-storage;2.1.1 in central
	found org.antlr#antlr4-runtime;4.8 in central
	found org.codehaus.jackson#jackson-core-asl;1.9.13 in central
:: resolution report :: resolve 214ms :: artifacts dl 8ms
	:: modules in use:
	io.delta#delta-core_2.12;2.1.1 from central in [default]
	io.delta#delta-storage;2.1.1 from central in [default]
	org.antlr#antlr4-runtime;4.8 from central in [default]
	org.codehaus.jackson#jackson-core-asl;1.9.13 from central in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   4   |   0   |   0   |   0   ||   4   |   0   |
	---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-d50c196c-7782-4293-b6ec-3c81ffd334e4
	confs: [default]
	0 artifacts copied, 4 already retrieved (0kB/5ms)
23/02/20 17:08:17 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
2023-02-20 17:08:29.534 | INFO     | __main__:get_activity_cards:36 - Fetched the refined cards data from silver table
2023-02-20 17:08:37.000 | SUCCESS  | __main__:get_activity_cards:52 - 
 Saved raghava cards data to /home/lakeuser/lakehouse_project/data_tables/raghava_cards_gold_path
2023-02-20 17:08:37.000 | INFO     | __main__:get_activity_cards:54 - Saved raghava cards data for boardto /home/lakeuser/lakehouse_project/data_tables/raghava_cards_gold_path table