### PR TITLE
Mohan delta lake fetch trello gold table data

### DIFF
--- a/jobs/mohan_gold_data.py
+++ b/jobs/mohan_gold_data.py
@@ -49,7 +49,6 @@ def get_user_cards(spark, start_date, end_date):
         #Write the data to Delta Lake Gold table
         filtered_cards_data.write.format('delta').mode(
             "overwrite").option("mergeSchema", 'true').save(path)    
-
         logger.success(
             f'\n Saved user card data for the given data range')
         logger.info(
@@ -59,7 +58,6 @@ def get_user_cards(spark, start_date, end_date):
         logger.exception(
             f'Exception while fetching cards data')
         raise error
-
 
 def perform_user_cards_aggregation_to_gold(start_date, end_date):
     """

--- a/jobs/mohan_gold_data.py
+++ b/jobs/mohan_gold_data.py
@@ -1,0 +1,88 @@
+"""
+This script will fetch all the cards from silver unique cards table and 
+- filter the table for specific user
+- filter data for specific timeframe passed in the script
+- save it to user Delta Lake Gold table
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+import argparse
+from loguru import logger
+from pyspark.sql.functions import col, from_utc_timestamp, to_date
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from helpers import spark_helper as sh, common_functions as cf, trello_functions as tf
+from config import delta_table_conf as dc
+
+def get_user_cards(spark, start_date, end_date):
+    """
+    Fetch all the cards data for the given user within the given date range 
+    and save it into a Delta Lake Gold table
+    :param spark: Spark session
+    :param start_date: start date
+    :param end_date: end date
+    :return none
+    """
+    path = dc.mohan_cards_gold_path
+    try:
+        # Fetch the cards data from the refined cards silver delta table
+        refined_cards_data = spark.read.format(
+            "delta").load(dc.cards_unique_silver_table_path)
+        logger.info(
+            f'Fetched refined card data from silver delta table')      
+
+        # Convert from_date to a datetime object
+        start_date = datetime.strptime(start_date, '%Y-%m-%d')
+
+        # Convert "dateLastActivity" column to date format
+        refined_cards_data = refined_cards_data.withColumn("dateLastActivity", to_date(from_utc_timestamp("dateLastActivity", "UTC")))
+
+        # Filter the DataFrame for the given user and date range
+        filtered_cards_data = refined_cards_data.filter(col("card_members").contains('mohan') & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
+        logger.info(f'Fetched user card data within the date range')  
+
+        #Select the required columns
+        filtered_cards_data = filtered_cards_data.select(
+            "id", "name", "LastUpdated", "board_name")
+
+        #Write the data to Delta Lake Gold table
+        filtered_cards_data.write.format('delta').mode(
+            "overwrite").option("mergeSchema", 'true').save(path)    
+
+        logger.success(
+            f'\n Saved user card data for the given data range')
+        logger.info(
+            f'Saved user card data to {path} table')    
+
+    except Exception as error:
+        logger.exception(
+            f'Exception while fetching cards data')
+        raise error
+
+
+def perform_user_cards_aggregation_to_gold(start_date, end_date):
+    """
+    Run the steps to get all the data of cards within the provided dates and place it Delta Lake Gold table
+    """
+    logger.info("Starting the job to fetch all the cards for the given dates")
+    try:
+        # Get SparkSession and SparkContext
+        spark, context = sh.start_spark()
+
+        # Fetch all cards for the given date range
+        get_user_cards(spark, start_date, end_date)
+        logger.success('Completed get user cards by date range job')
+
+    except Exception as error:
+        logger.exception(
+            f'Failure in job to fetch user card data between the dates {start_date} - {end_date}')
+        raise error
+
+# --------START OF SCRIPT
+if __name__ == "__main__":
+    PARSER = argparse.ArgumentParser(description='Create gold delta table')
+    PARSER.add_argument('--start_date', type=str, required=True, help='Start date in the format YYYY-MM-DD')
+    PARSER.add_argument('--end_date', type=str, required=True, help='End date in the format YYYY-MM-DD')
+    ARGS = PARSER.parse_args()
+    perform_user_cards_aggregation_to_gold(ARGS.start_date, ARGS.end_date)

--- a/jobs/mohan_gold_data.py
+++ b/jobs/mohan_gold_data.py
@@ -39,7 +39,7 @@ def get_user_cards(spark, start_date, end_date):
         refined_cards_data = refined_cards_data.withColumn("dateLastActivity", to_date(from_utc_timestamp("dateLastActivity", "UTC")))
 
         # Filter the DataFrame for the given user and date range
-        filtered_cards_data = refined_cards_data.filter(col("card_members").contains('mohan') & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
+        filtered_cards_data = refined_cards_data.filter(col("card_members").contains('Mohan Kumar') & (col("dateLastActivity") >= start_date) & (col("dateLastActivity") <= end_date))
         logger.info(f'Fetched user card data within the date range')  
 
         #Select the required columns


### PR DESCRIPTION
- Created a new script `mohan_gold_data.py` under /delta-lake-trello/jobs/.

- Run command: "python jobs/mohan_gold_data.py --start_date 2021-01-01 --end_date 2022-01-01" 
- Output:
```
Starting the job to fetch all the cards for the given dates
:: loading settings :: url = jar:file:/home/lakeuser/lakehouse_project/venv/lib/python3.8/site-packages/pyspark/jars/ivy-2.5.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
Ivy Default Cache set to: /home/lakeuser/.ivy2/cache
The jars for the packages stored in: /home/lakeuser/.ivy2/jars
io.delta#delta-core_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-55f0d8dd-1a4a-4bda-983c-a16d6da549d0;1.0
        confs: [default]
        found io.delta#delta-core_2.12;2.1.1 in central
        found io.delta#delta-storage;2.1.1 in central
        found org.antlr#antlr4-runtime;4.8 in central
        found org.codehaus.jackson#jackson-core-asl;1.9.13 in central
:: resolution report :: resolve 226ms :: artifacts dl 8ms
        :: modules in use:
        io.delta#delta-core_2.12;2.1.1 from central in [default]
        io.delta#delta-storage;2.1.1 from central in [default]
        org.antlr#antlr4-runtime;4.8 from central in [default]
        org.codehaus.jackson#jackson-core-asl;1.9.13 from central in [default]
        ---------------------------------------------------------------------
        |                  |            modules            ||   artifacts   |
        |       conf       | number| search|dwnlded|evicted|| number|dwnlded|
        ---------------------------------------------------------------------
        |      default     |   4   |   0   |   0   |   0   ||   4   |   0   |
        ---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-55f0d8dd-1a4a-4bda-983c-a16d6da549d0
        confs: [default]
        0 artifacts copied, 4 already retrieved (0kB/20ms)
23/02/28 07:59:27 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
2023-02-28 07:59:38.879 | INFO     | __main__:get_user_cards:32 - Fetched refined card data from silver delta table
2023-02-28 07:59:38.977 | INFO     | __main__:get_user_cards:43 - Fetched user card data within the date range
2023-02-28 07:59:45.349 | SUCCESS  | __main__:get_user_cards:52 -
 Saved user card data for the given data range
2023-02-28 07:59:45.349 | INFO     | __main__:get_user_cards:54 - Saved user card data to /home/lakeuser/lakehouse_project/data_tables/mohan_cards_gold_path table
2023-02-28 07:59:45.349 | SUCCESS  | __main__:perform_user_cards_aggregation_to_gold:73 - Completed get user cards by date range job
```